### PR TITLE
removing on-headers, as it is no longer a transitive dependency

### DIFF
--- a/kmc-sa-mgmt/kmc-sa-gui/src/main/frontend/package.json
+++ b/kmc-sa-mgmt/kmc-sa-gui/src/main/frontend/package.json
@@ -21,7 +21,6 @@
     "form-data": "^4.0.4",
     "formik": "^2.4.6",
     "notistack": "^3.0.2",
-    "on-headers": "^1.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-table": "^7.8.0",

--- a/kmc-sa-mgmt/kmc-sa-gui/src/main/frontend/yarn.lock
+++ b/kmc-sa-mgmt/kmc-sa-gui/src/main/frontend/yarn.lock
@@ -1375,7 +1375,7 @@ form-data@^4.0.0:
 
 form-data@^4.0.4:
   version "4.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
@@ -1713,11 +1713,6 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
-on-headers@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.1.0.tgz#59da4f91c45f5f989c6e4bcedc5a3b0aed70ff65"
-  integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==
 
 optionator@^0.9.3:
   version "0.9.4"


### PR DESCRIPTION
https://github.com/NASA-AMMOS/DCS/security/dependabot/1 notes that `on-headers` is a transitive dependency of `react-scripts`, which is no longer used.