### PR TITLE
update DCS version number to 4.0.0

### DIFF
--- a/kmc-crypto-client/pom.xml
+++ b/kmc-crypto-client/pom.xml
@@ -6,13 +6,13 @@
   <groupId>gov.nasa.jpl.ammos.kmc</groupId>
   <artifactId>kmc-crypto-client</artifactId>
   <packaging>jar</packaging>
-  <version>3.7.0</version>
-  <name>ASEC KMC Cryptography API Service Client</name>
+  <version>4.0.0</version>
+  <name>DCS Cryptography API Service Client</name>
 
   <parent>
     <groupId>gov.nasa.jpl.ammos.kmc</groupId>
     <artifactId>asec-kmc</artifactId>
-    <version>3.7.0</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/kmc-crypto-library/pom.xml
+++ b/kmc-crypto-library/pom.xml
@@ -6,13 +6,13 @@
   <groupId>gov.nasa.jpl.ammos.kmc</groupId>
   <artifactId>kmc-crypto-library</artifactId>
   <packaging>jar</packaging>
-  <version>3.7.0</version>
-  <name>ASEC KMC Cryptography API Library</name>
+  <version>4.0.0</version>
+  <name>DCS Cryptography API Library</name>
   
   <parent>
     <groupId>gov.nasa.jpl.ammos.kmc</groupId>
     <artifactId>asec-kmc</artifactId>
-    <version>3.7.0</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kmc-crypto-service/pom.xml
+++ b/kmc-crypto-service/pom.xml
@@ -5,13 +5,13 @@
   <groupId>gov.nasa.jpl.ammos.kmc</groupId>
   <artifactId>kmc-crypto-service</artifactId>
   <packaging>jar</packaging>
-  <version>3.7.0</version>
-  <name>ASEC KMC Cryptography API Service</name>
+  <version>4.0.0</version>
+  <name>DCS Cryptography API Service</name>
 
   <parent>
     <groupId>gov.nasa.jpl.ammos.kmc</groupId>
     <artifactId>asec-kmc</artifactId>
-    <version>3.7.0</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kmc-crypto/pom.xml
+++ b/kmc-crypto/pom.xml
@@ -6,13 +6,13 @@
   <groupId>gov.nasa.jpl.ammos.kmc</groupId>
   <artifactId>${final.name}</artifactId>
   <packaging>jar</packaging>
-  <version>3.7.0</version>
-  <name>ASEC KMC Cryptography API</name>
+  <version>4.0.0</version>
+  <name>DCS Cryptography API</name>
 
   <parent>
     <groupId>gov.nasa.jpl.ammos.kmc</groupId>
     <artifactId>asec-kmc</artifactId>
-    <version>3.7.0</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/kmc-key-client/pom.xml
+++ b/kmc-key-client/pom.xml
@@ -6,8 +6,8 @@
   <groupId>gov.nasa.jpl.ammos.kmc</groupId>
   <artifactId>kmc-key-client</artifactId>
   <packaging>jar</packaging>
-  <version>3.7.0</version>
-  <name>ASEC KMC Key Client</name>
+  <version>4.0.0</version>
+  <name>DCS Key Client</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/kmc-resources/packaging/container/crypto-service/README.md
+++ b/kmc-resources/packaging/container/crypto-service/README.md
@@ -1,44 +1,44 @@
-# KMC Crypto Service Container
+# DCS Crypto Service Container
 
-The KMC Crypto Service Container provides a self-contained KMC Crypto Service offering data-level cryptography.  KMC, including the Crypto Service Container is available under the Apache 2.0 software license, but this container is based on the Red Hat Enterprise Linux (RHEL) 9 Universal Basic Image (UBI), which is subject to their licensing terms.  See https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI for specifics about the RHEL 9 UBI licensing.
+The DCS Crypto Service Container provides a self-contained DCS Crypto Service offering data-level cryptography.  DCS, including the Crypto Service Container is available under the Apache 2.0 software license, but this container is based on the Red Hat Enterprise Linux (RHEL) 9 Universal Basic Image (UBI), which is subject to their licensing terms.  See https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI for specifics about the RHEL 9 UBI licensing.
 
 ## Building the Container
 
-Follow the instructions in the root level README.md to configure and build KMC.  In particular, make sure to configure the CONTAINER_EXEC variable in setenv.sh to match your local container engine. CONTAINER_EXEC defaults to /bin/podman, since that is the default container virtualzation package offered on Red Hat Enterprise Linux 9.  Once the build is complete, use the deploy.sh script to execute the container builds.
+Follow the instructions in the root level README.md to configure and build DCS.  In particular, make sure to configure the CONTAINER_EXEC variable in setenv.sh to match your local container engine. CONTAINER_EXEC defaults to /bin/podman, since that is the default container virtualzation package offered on Red Hat Enterprise Linux 9.  Once the build is complete, use the deploy.sh script to execute the container builds.
 
-From the root of the KMC repository, run the following command once the build and tests are complete:
+From the root of the DCS repository, run the following command once the build and tests are complete:
 ```kmc-resources/scripts/deploy.sh --img```
 
-That command will deploy all of the KMC files into a local directory (kmc-resources/packaging/container/kmcroot) and then execute the container build process using the Dockerfile in each of the service container trees.  The container build process requires access to the Internet for two things: 
+That command will deploy all of the DCS files into a local directory (kmc-resources/packaging/container/kmcroot) and then execute the container build process using the Dockerfile in each of the service container trees.  The container build process requires access to the Internet for two things: 
 * Retrieval of the RHEL9 UBI image
 * Download of the BouncyCastle FIPS Java library from Maven Central, which is used to support FIPS-compliant keystores.
 
-At the end of the container build process, there should be three KMC containers in your local image repository (examples shown using podman):
+At the end of the container build process, there should be three DCS containers in your local image repository (examples shown using podman):
 
 ```
 $ podman image ls
 REPOSITORY                                  TAG         IMAGE ID      CREATED            SIZE
-localhost/kmc-sa-mgmt-service               3.7.0       aebf0191473b  About an hour ago  890 MB
-localhost/kmc-sdls-service                  3.7.0       cfb068d65d92  About an hour ago  890 MB
-localhost/kmc-crypto-service                3.7.0       2e1285394471  About an hour ago  890 MB
+localhost/kmc-sa-mgmt-service               4.0.0       aebf0191473b  About an hour ago  890 MB
+localhost/kmc-sdls-service                  4.0.0       cfb068d65d92  About an hour ago  890 MB
+localhost/kmc-crypto-service                4.0.0       2e1285394471  About an hour ago  890 MB
 ```
 
 The image can be saved to transferrable image files with the following commands:
 ```
-$ podman image save -o kmc-crypto-service-3.7.0.tar kmc-crypto-service:3.7.0
+$ podman image save -o kmc-crypto-service-4.0.0.tar kmc-crypto-service:4.0.0
 ```
 
 ## Crypto Service Container Configuration Options
-There are a large number of configurable options that control the behavior and operation of the KMC Crypto Service Container.  The full list is documented here.
+There are a large number of configurable options that control the behavior and operation of the DCS Crypto Service Container.  The full list is documented here.
 
 Some of the configuration options are "sensitive" data -- TLS keys, keystores, passwords, etc.  It is *STRONGLY RECOMMENDED* that secure methods be used to provide these configuration items to the container.  Podman/docker secrets, Amazon Secrets Manager, and similar systems can and should be used for any configuration options marked "Sensitive."  
 
 
 ## Deploying the Crypto Service Container
 
-The KMC Crypto Service Container can be deployed via a wide variety of tools and processes.  Examples are provided for running the bare container with podman and using podman-compose.  Releases of the Crypto Service Container are also tested in the Amazon Elastic Container Service (ECS), and can be run there.  The KMC Crypto Service Container should be deployable on any container virtualization system that supports OCI-compliant images and processes.
+The DCS Crypto Service Container can be deployed via a wide variety of tools and processes.  Examples are provided for running the bare container with podman and using podman-compose.  Releases of the Crypto Service Container are also tested in the Amazon Elastic Container Service (ECS), and can be run there.  The DCS Crypto Service Container should be deployable on any container virtualization system that supports OCI-compliant images and processes.
 
-There are a large number of configurable options that control the behavior and operation of the KMC Crypto Service Container.  For the full list, see "Crypto Service Container Configuration Options" above. These examples are minimalist configurations that utilize the default settings as much as possible.  
+There are a large number of configurable options that control the behavior and operation of the DCS Crypto Service Container.  For the full list, see "Crypto Service Container Configuration Options" above. These examples are minimalist configurations that utilize the default settings as much as possible.  
 
 Both examples below use podman secrets for sensitive configuration information, as well as for a simple method to provide some non-sensitive options (like the TLS CA Certificate Bundle).
 
@@ -46,7 +46,7 @@ Both examples below use podman secrets for sensitive configuration information, 
 
 1. Import the Image (optional, if image is available in a configured repository)
 ```bash
-$ podman image load -i kmc-crypto-service-3.7.0.tar.gz
+$ podman image load -i kmc-crypto-service-4.0.0.tar.gz
 ```
 
 1. Configure Secrets
@@ -60,13 +60,13 @@ $ echo "changeit" | podman secret create tls_mtls_truststore_pass -
 $ echo "s00p3rs3cr3tp@ssph4se" | podman secret create crypto_keystore_pass -
 ```
 
-1. Create KMC Crypto Service Container
+1. Create DCS Crypto Service Container
 ```bash
 podman container create -p 8443:8443 --name kmc-crypto-service \
   --secret tls_host_key --secret tls_host_cert --secret tls_ca_bundle \
   --secret crypto_keystore --secret crypto_keystore_pass \
   --secret crypto_key_pass --secret tls_mtls_truststore \
-  kmc-crypto-service:3.7.0
+  kmc-crypto-service:4.0.0
 ```
 
 1. Create SystemD Unit file for container (if desired)
@@ -91,11 +91,11 @@ podman start kmc-crypto-service
 ```
 
 ### Deploying with podman-compose
-Podman-compose uses YAML-formatted files to configure one or more services.  An example podman-compose file for the KMC Crypto Service Container can be found in kmc-resources/packaging/container/crypto-service/podman-compose-example.yml.  This example compose file uses podman secrets like the previous example to manage sensitive inputs.
+Podman-compose uses YAML-formatted files to configure one or more services.  An example podman-compose file for the DCS Crypto Service Container can be found in kmc-resources/packaging/container/crypto-service/podman-compose-example.yml.  This example compose file uses podman secrets like the previous example to manage sensitive inputs.
 
 1. Import the Image (optional, if image is available in a configured repository)
 ```bash
-$ podman image load -i kmc-crypto-service-3.7.0.tar.gz
+$ podman image load -i kmc-crypto-service-4.0.0.tar.gz
 ```
 
 1. Configure Secrets

--- a/kmc-resources/packaging/rpm/SPECS/kmc.spec
+++ b/kmc-resources/packaging/rpm/SPECS/kmc.spec
@@ -1,19 +1,19 @@
 Name:           kmc
 Version:        %{kmc_version}
 Release:        1%{?dist}
-Summary:        AMMOS Key Management & Cryptography Tools
+Summary:        AMMOS Data Cryptography Services (DCS)
 
 AutoReqProv:    no
 Provides:       ammos(kmc) = %{version}-%{release}
 
 License:        Apache 2.0
-URL:            https://github.com/NASA-AMMOS/KMC
+URL:            https://github.com/NASA-AMMOS/DCS
 
 %description
-AMMOS KMC provides data-level encryption/decryption and integrity check value (ICV) creation/ verification capabilities for securing data at-rest (and in-transit, as an additional layer of protection over secure connections), and implements the CCSDS Space Data Link Security (SDLS) protocol for doing transfer frame encryption.
+AMMOS DCS provides data-level encryption/decryption and integrity check value (ICV) creation/ verification capabilities for securing data at-rest (and in-transit, as an additional layer of protection over secure connections), and implements the CCSDS Space Data Link Security (SDLS) protocol for doing transfer frame encryption.
 
 %package        crypto-service
-Summary:        AMMOS Key Management & Cryptography Crypto Service
+Summary:        AMMOS Data Cryptography Services (DCS)
 Version:        %{version}
 License:        Apache 2.0
 AutoReqProv:    no

--- a/kmc-resources/scripts/build.sh
+++ b/kmc-resources/scripts/build.sh
@@ -3,7 +3,7 @@
 # uncomment for debug
 #set -x
 
-echo "Compile and build KMC" 
+echo "Compile and build DCS"
 
 source $(dirname "$0")/setenv.sh
 
@@ -52,28 +52,28 @@ echo "----------------------------------------"
 cd $SRC_KMIP; mvn -q clean
 cd $SRC_KMIP; $MVN install -DDEFAULT_PREFIX="${PREFIX}" -DDEFAULT_BINPATH="${BINPATH}" -DDEFAULT_LIBPATH="${LIBPATH}" -DDEFAULT_CFGPATH="${CFGPATH}" -DDEFAULT_LOGPATH="${LOGPATH}"
 echo "----------------------------------------"
-echo "KMC Key Client Library"
+echo "DCS Key Client Library"
 echo "----------------------------------------"
 cd $SRC_KMC/kmc-key-client ; $MVN install -DDEFAULT_PREFIX="${PREFIX}" -DDEFAULT_BINPATH="${BINPATH}" -DDEFAULT_LIBPATH="${LIBPATH}" -DDEFAULT_CFGPATH="${CFGPATH}" -DDEFAULT_LOGPATH="${LOGPATH}"
 echo "----------------------------------------"
-echo "KMC Crypto Interface"
+echo "DCS Crypto Interface"
 echo "----------------------------------------"
 cd $SRC_KMC/kmc-crypto ; $MVN install -DDEFAULT_PREFIX="${PREFIX}" -DDEFAULT_BINPATH="${BINPATH}" -DDEFAULT_LIBPATH="${LIBPATH}" -DDEFAULT_CFGPATH="${CFGPATH}" -DDEFAULT_LOGPATH="${LOGPATH}"
 echo "----------------------------------------"
-echo "KMC Crypto Library"
+echo "DCS Crypto Library"
 echo "----------------------------------------"
 cd $SRC_KMC/kmc-crypto-library ; $MVN install -DDEFAULT_PREFIX="${PREFIX}" -DDEFAULT_BINPATH="${BINPATH}" -DDEFAULT_LIBPATH="${LIBPATH}" -DDEFAULT_CFGPATH="${CFGPATH}" -DDEFAULT_LOGPATH="${LOGPATH}"
 echo "----------------------------------------"
-echo "KMC Crypto Client"
+echo "DCS Crypto Client"
 echo "----------------------------------------"
 cd $SRC_KMC/kmc-crypto-client ; $MVN install -DDEFAULT_PREFIX="${PREFIX}" -DDEFAULT_BINPATH="${BINPATH}" -DDEFAULT_LIBPATH="${LIBPATH}" -DDEFAULT_CFGPATH="${CFGPATH}" -DDEFAULT_LOGPATH="${LOGPATH}"
 echo "----------------------------------------"
-echo "KMC Crypto Service"
+echo "DCS Crypto Service"
 echo "----------------------------------------"
 cd $SRC_KMC/kmc-crypto-service ; $MVN package -DDEFAULT_PREFIX="${CRYPTOSVC_PREFIX}" -DDEFAULT_BINPATH="${CRYPTOSVC_PREFIX}/bin" -DDEFAULT_LIBPATH="${CRYTPOSVC_LIBPATH}" -DDEFAULT_CFGPATH="${CRYPTOSVC_CFGPATH}" -DDEFAULT_LOGPATH="${CRYPTOSVC_LOGPATH}"
 
 echo "----------------------------------------"
-echo "KMC SDLS Service"
+echo "DCS SDLS Service"
 echo "----------------------------------------"
 cd $SRC_KMC/kmc-sdls-service
 export LD_LIBRARY_PATH=${SRC_CRYPTO_LIB}/build/lib
@@ -86,7 +86,7 @@ mvn eclipse:eclipse
 mvn -q package -DDEFAULT_PREFIX="${SDLSSVC_PREFIX}" -DDEFAULT_BINPATH="${SDLSSVC_PREFIX}/bin" -DDEFAULT_LIBPATH="${SDLSSVC_LIBPATH}" -DDEFAULT_CFGPATH="${SDLSSVC_CFGPATH}" -DDEFAULT_LOGPATH="${SDLSSVC_LOGPATH}"
 
 echo "----------------------------------------"
-echo "KMC SA Management"
+echo "DCS SA Management"
 echo "----------------------------------------"
 cd $SRC_KMC/kmc-sa-mgmt ; mvn -q package -DDEFAULT_PREFIX="${SAMGMTSVC_PREFIX}" -DDEFAULT_BINPATH="${SAMGMTSVC_PREFIX}/bin" -DDEFAULT_LIBPATH="${SAMGMTSVC_LIBPATH}" -DDEFAULT_CFGPATH="${SAMGMTSVC_CFGPATH}" -DDEFAULT_LOGPATH="${SAMGMTSVC_LOGPATH}" # will run the tests
 
@@ -95,12 +95,12 @@ if [ "$1" == "skip-test" ]; then
   cd $SRC_KMC/kmc-crypto-client ; mvn jar:test-jar
 else
   echo "----------------------------------------"
-  echo "KMC Crypto Library Tests"
+  echo "DCS Crypto Library Tests"
   echo "----------------------------------------"
   cd $SRC_KMC/kmc-crypto-library ; mvn test ; mvn jar:test-jar
 
   echo "----------------------------------------"
-  echo "KMC Crypto Client Tests"
+  echo "DCS Crypto Client Tests"
   echo "----------------------------------------"
   cd $SRC_KMC/kmc-crypto-client ; mvn test ; mvn jar:test-jar
 fi

--- a/kmc-resources/scripts/build.sh
+++ b/kmc-resources/scripts/build.sh
@@ -23,6 +23,7 @@ echo "----------------------------------------"
 echo "----------------------------------------"
 echo "AMMOS CryptoLib"
 echo "----------------------------------------"
+if [ -x /usr/bin/cmake ]; then
 cd $SRC_CRYPTO_LIB
 if [ -f CMakeCache.txt ]; then
   make clean
@@ -40,6 +41,9 @@ if [ $? != 0 ]; then
   exit 1
 fi
 make install >> make.out
+else
+  echo "Skip building CryptoLib as cmake not found"
+fi
 echo "----------------------------------------"
 
 cd $SRC_KMC; mvn -q clean

--- a/kmc-resources/scripts/setenv.sh
+++ b/kmc-resources/scripts/setenv.sh
@@ -96,7 +96,7 @@ CONTAINER_EXEC="/bin/podman"
 
 # Do not edit settings below -- needed for build steps
 pushd $(dirname "$0") >/dev/null 2>&1
-if [ -r /bin/git ]; then
+if [ -x /usr/bin/git ]; then
   ROOT=$(git rev-parse --show-toplevel)
   DIST=$ROOT
   BUILD_DIR=$DIST/build$BUILD/build

--- a/kmc-resources/scripts/setenv.sh
+++ b/kmc-resources/scripts/setenv.sh
@@ -1,4 +1,4 @@
-VERSION=3.7.0
+VERSION=4.0.0
 
 # Deployment Settings
 CRYPTO_SERVICE_FQDN="crypto.example.com"

--- a/kmc-sa-mgmt/kmc-sa-cli/pom.xml
+++ b/kmc-sa-mgmt/kmc-sa-cli/pom.xml
@@ -18,13 +18,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
-    <version>3.7.0</version>
-    <name>ASEC KMC SA CLI Application</name>
+    <version>4.0.0</version>
+    <name>DCS SA CLI Application</name>
 
     <parent>
         <artifactId>kmc-sa-mgmt</artifactId>
         <groupId>gov.nasa.jpl.ammos.kmc</groupId>
-        <version>3.7.0</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -127,16 +127,10 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <reuseForks>false</reuseForks>
-                    <forkCount>1</forkCount>
                 </configuration>
             </plugin>
             <!-- Appassembler creates the repository layout and bin script -->
@@ -216,7 +210,7 @@
                 <executions>
                     <execution>
                         <id>unpack</id>
-                        <phase>prepare-package</phase>
+                        <phase>generate-test-sources</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>
                         </goals>
@@ -282,9 +276,18 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <configuration>
+                    <downloadSources>true</downloadSources>
+                    <downloadJavadocs>true</downloadJavadocs>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>

--- a/kmc-sa-mgmt/kmc-sa-db-api/pom.xml
+++ b/kmc-sa-mgmt/kmc-sa-db-api/pom.xml
@@ -19,13 +19,13 @@
 
     <artifactId>kmc-sa-db-api</artifactId>
     <packaging>jar</packaging>
-    <version>3.7.0</version>
-    <name>ASEC KMC SA DB API</name>
+    <version>4.0.0</version>
+    <name>DCS SA DB API</name>
 
     <parent>
         <artifactId>kmc-sa-mgmt</artifactId>
         <groupId>gov.nasa.jpl.ammos.kmc</groupId>
-        <version>3.7.0</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -86,6 +86,16 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <configuration>
+                    <downloadSources>true</downloadSources>
+                    <downloadJavadocs>true</downloadJavadocs>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/kmc-sa-mgmt/kmc-sa-db-lib/pom.xml
+++ b/kmc-sa-mgmt/kmc-sa-db-lib/pom.xml
@@ -19,13 +19,13 @@
 
     <artifactId>kmc-sa-db-lib</artifactId>
     <packaging>jar</packaging>
-    <version>3.7.0</version>
-    <name>ASEC KMC SA DB Library</name>
+    <version>4.0.0</version>
+    <name>DCS SA DB Library</name>
 
     <parent>
         <artifactId>kmc-sa-mgmt</artifactId>
         <groupId>gov.nasa.jpl.ammos.kmc</groupId>
-        <version>3.7.0</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -94,6 +94,16 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <configuration>
+                    <downloadSources>true</downloadSources>
+                    <downloadJavadocs>true</downloadJavadocs>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -199,16 +209,16 @@
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bctls-fips</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bc-fips</artifactId>
-        </dependency>
+    
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bctls-fips</artifactId>
+      </dependency>
+    
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bc-fips</artifactId>
+      </dependency>
     </dependencies>
 
     <repositories>

--- a/kmc-sa-mgmt/kmc-sa-gui/README.md
+++ b/kmc-sa-mgmt/kmc-sa-gui/README.md
@@ -1,6 +1,6 @@
-# KMC SA Management GUI
+# DCS SA Management GUI
 
-Author: [JP Pan (393C)](mailto:panjames@jpl.nasa.gov?subject=KMC SA Management GUI)
+Author: [JP Pan (393C)](mailto:panjames@jpl.nasa.gov?subject=DCS SA Management GUI)
 
 - Spring Boot web service
 - React frontend (CRA)

--- a/kmc-sa-mgmt/kmc-sa-gui/pom.xml
+++ b/kmc-sa-mgmt/kmc-sa-gui/pom.xml
@@ -21,48 +21,49 @@
     <parent>
         <artifactId>kmc-sa-mgmt</artifactId>
         <groupId>gov.nasa.jpl.ammos.kmc</groupId>
-        <version>3.7.0</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <groupId>groupId</groupId>
     <artifactId>kmc-sa-gui</artifactId>
-    <name>ASEC KMC SA GUI Server and Frontend</name>
-    <version>3.7.0</version>
+    <name>DCS SA GUI Server and Frontend</name>
+    <version>4.0.0</version>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <frontend-src-dir>${project.basedir}/src/main/frontend</frontend-src-dir>
-        <node.version>v23.1.0</node.version>
-        <yarn.version>v1.22.22</yarn.version>
+        <node.version>v18.3.0</node.version>
+        <yarn.version>v1.22.19</yarn.version>
         <!-- yarn-registry-url is the default Yarn regestry URL used for retreving packages.  -->
         <!-- Allows for use of a local repo to force cacheing, preservation of dependenices, or use of alterntate dependencies.  -->
         <!-- Consider setting the property yarn-registry-url in an active profile your maven settings.xml if you would rather not modify this file. -->
         <!-- When set to empty, Yarn ignores this option and uses system defaults  -->
         <yarn-registry-url></yarn-registry-url>
-
-        <frontend-maven-plugin.version>1.15.1</frontend-maven-plugin.version>
+        
+        <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
         <final.name>kmc-sa-mgmt</final.name>
         <app.profiles>mTLS</app.profiles>
         <spring.profiles.active>${app.profiles}</spring.profiles.active>
-        <!--  SEE PARENT POM for configuration of these options, they have been moved there.
-         <DEFAULT_BINPATH></DEFAULT_BINPATH>
-         <DEFAULT_LIBPATH></DEFAULT_LIBPATH>
-         <DEFAULT_CFGPATH></DEFAULT_CFGPATH>
-         <DEFAULT_LOGPATH></DEFAULT_LOGPATH> -->
-
+       <!--  SEE PARENT POM for configuration of these options, they have been moved there.
+        <DEFAULT_BINPATH></DEFAULT_BINPATH>
+        <DEFAULT_LIBPATH></DEFAULT_LIBPATH>
+        <DEFAULT_CFGPATH></DEFAULT_CFGPATH>
+        <DEFAULT_LOGPATH></DEFAULT_LOGPATH> -->
+        
         <DEFAULT_PREFIX>${DEFAULT_KMC_ROOT}/services/${final.name}</DEFAULT_PREFIX>
         <DEFAULT_TOMCAT_PREFIX>${DEFAULT_PREFIX}</DEFAULT_TOMCAT_PREFIX>
         <DEFAULT_PORT>8447</DEFAULT_PORT>
         <DEFAULT_ALLOWED_CIPHERS>
-            TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,\
-            TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,\
-            TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,\
-            TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,\
-            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,\
-            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,\
-            TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,\
-            TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,\
+        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,\
+        TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,\
+        TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,\
+        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,\
+        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,\
+        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,\
+        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         </DEFAULT_ALLOWED_CIPHERS>
         <DEFAULT_KEYSTORE>/etc/pki/tls/private/ammos-server-keystore.bcfks</DEFAULT_KEYSTORE>
         <DEFAULT_KEYSTORE_PASSWORD>changeit</DEFAULT_KEYSTORE_PASSWORD>
@@ -74,7 +75,7 @@
         <DEFAULT_TRUSTSTORE_TYPE>JKS</DEFAULT_TRUSTSTORE_TYPE>
         <DEFAULT_CLIENT_AUTH>NEED</DEFAULT_CLIENT_AUTH>
         <DEFAULT_ENABLED_PROTOCOLS>TLSv1.2</DEFAULT_ENABLED_PROTOCOLS>
-    </properties>
+        </properties>
 
     <profiles>
         <profile>
@@ -90,41 +91,6 @@
                 <DEFAULT_LOGPATH>${DEFAULT_PREFIX}/log</DEFAULT_LOGPATH>
                 <DEFAULT_KEYSTORE>${DEFAULT_LIBPATH}/</DEFAULT_KEYSTORE>
             </properties>
-        </profile>
-        <profile>
-            <id>no-frontend</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.eirslett</groupId>
-                        <artifactId>frontend-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>install-frontend-tools</id>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>yarn-install</id>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>build-frontend</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-resources-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>copy-frontend</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 
@@ -148,7 +114,7 @@
                     <goal>clean</goal>
                     <filesets>
                         <fileset>
-                            <directory>${project.basedir}/src/main/frontend/dist</directory>
+                            <directory>${project.basedir}/src/main/frontend/build</directory>
                         </fileset>
                     </filesets>
                 </configuration>
@@ -168,9 +134,8 @@
                     <profiles>${app.profiles}</profiles>
                     <mainClass>gov.nasa.jpl.ammos.asec.kmc.saserver.app.KmcSaMgmt</mainClass>
                     <layout>ZIP</layout>
-                    <loaderImplementation>CLASSIC</loaderImplementation>
                 </configuration>
-                <executions>
+                    <executions>
                     <execution>
                         <goals>
                             <goal>repackage</goal>
@@ -185,8 +150,8 @@
                 <configuration>
                     <nodeVersion>${node.version}</nodeVersion>
                     <yarnVersion>${yarn.version}</yarnVersion>
-                    <workingDirectory>src/main/frontend</workingDirectory>
-                    <srcdir>src/main/frontend</srcdir>
+                    <workingDirectory>${frontend-src-dir}</workingDirectory>
+                    <srcdir>${frontend-src-dir}</srcdir>
                     <installDirectory>target</installDirectory>
                     <environmentVariables>
                         <YARN_REGISTRY>${yarn-registry-url}
@@ -235,13 +200,13 @@
                             <outputDirectory>${project.build.outputDirectory}/static</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>${project.basedir}/src/main/frontend/dist</directory>
+                                    <directory>${project.basedir}/src/main/frontend/build</directory>
                                 </resource>
                             </resources>
                             <delimiters>
-                                <delimiter>@</delimiter>
-                            </delimiters>
-                            <useDefaultDelimiters>false</useDefaultDelimiters>
+		                    	<delimiter>@</delimiter>
+	                    	</delimiters>
+	                    	<useDefaultDelimiters>false</useDefaultDelimiters>
                         </configuration>
                     </execution>
                 </executions>
@@ -271,6 +236,22 @@
                     </execution>
                 </executions>
             </plugin>
+        <!--     <plugin>
+
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                    <manifest>
+                        <addClasspath>true</addClasspath>
+                        <classpathPrefix>lib/</classpathPrefix>
+                        <mainClass>gov.nasa.jpl.ammos.asec.kmc.saserver.app.KmcSaMgmt</mainClass>
+                    </manifest>
+                    </archive>
+                </configuration>
+            </plugin> -->
+            
         </plugins>
     </build>
 
@@ -295,10 +276,10 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-logging</artifactId>
                 </exclusion>
-                <!--    <exclusion>
-                       <groupId>org.springframework.boot</groupId>
-                       <artifactId>spring-boot-starter-tomcat</artifactId>
-                   </exclusion> -->
+             <!--    <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion> -->
             </exclusions>
         </dependency>
         <dependency>

--- a/kmc-sa-mgmt/pom.xml
+++ b/kmc-sa-mgmt/pom.xml
@@ -17,25 +17,27 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>gov.nasa.jpl.ammos.kmc</groupId>
     <artifactId>kmc-sa-mgmt</artifactId>
     <packaging>pom</packaging>
-    <version>3.7.0</version>
-    <name>ASEC KMC SA Management</name>
+    <version>4.0.0</version>
+    <name>DCS SA Management</name>
 
     <parent>
         <groupId>gov.nasa.jpl.ammos.kmc</groupId>
         <artifactId>asec-kmc</artifactId>
-        <version>3.7.0</version>
+        <version>4.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hibernate.version>6.6.5.Final</hibernate.version>
-        <jackson.version>2.18.1</jackson.version>
-        <log4j.version>2.24.3</log4j.version>
-        <picocli.version>4.7.6</picocli.version>
-        <spring.boot.version>3.4.2</spring.boot.version>
+        <hibernate.version>6.2.7.Final</hibernate.version>
+        <jackson.version>2.15.3</jackson.version>
+        <log4j.version>2.24.2</log4j.version>
+        <picocli.version>4.7.4</picocli.version>
+        <spring.boot.version>2.7.17</spring.boot.version>
     </properties>
 
     <modules>
@@ -57,7 +59,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.2.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -67,12 +69,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -82,35 +84,37 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
-                    <configuration>
-                        <encoding>UTF-8</encoding>
-                    </configuration>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.11.1</version>
+                    <version>3.7.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-eclipse-plugin</artifactId>
+                    <version>2.10</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
@@ -120,29 +124,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.4.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.1.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.surefire</groupId>
-                        <artifactId>surefire-junit47</artifactId>
-                        <version>3.5.2</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
     </build>
 
     <reporting>
@@ -278,7 +263,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>2.2.220</version>
+                <version>2.1.212</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -350,6 +335,7 @@
                 <artifactId>bctls-fips</artifactId>
                 <version>2.0.19</version>
             </dependency>
+            
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bc-fips</artifactId>

--- a/kmc-sdls-service/pom.xml
+++ b/kmc-sdls-service/pom.xml
@@ -10,9 +10,9 @@
     </parent>
     <groupId>gov.nasa.jpl.ammos.asec.kmc</groupId>
     <artifactId>kmc-sdls-service</artifactId>
-    <version>3.7.0</version>
+    <version>4.0.0</version>
     <name>kmc-sdls-service</name>
-    <description>KMC SDLS REST Service</description>
+    <description>DCS SDLS REST Service</description>
     <properties>
         <java.version>17</java.version>
         <log4j.version>2.24.2</log4j.version>

--- a/kmip-client/pom.xml
+++ b/kmip-client/pom.xml
@@ -6,13 +6,13 @@
   <groupId>gov.nasa.jpl.ammos.kmc</groupId>
   <artifactId>kmip-client</artifactId>
   <packaging>jar</packaging>
-  <version>3.7.0</version>
-  <name>KMIP Client</name>
+  <version>4.0.0</version>
+  <name>DCS KMIP Client</name>
 
   <parent>
     <groupId>gov.nasa.jpl.ammos.kmc</groupId>
     <artifactId>asec-kmc</artifactId>
-    <version>3.7.0</version>
+    <version>4.0.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
 
   <groupId>gov.nasa.jpl.ammos.kmc</groupId>
   <artifactId>asec-kmc</artifactId>
-  <version>3.7.0</version>
+  <version>4.0.0</version>
   <packaging>pom</packaging>
-  <name>ASEC Key Management and Cryptography (KMC)</name>
+  <name>AMMOS Data Cryptography Services (DCS)</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
1) change DCS version number from 3.7.0 to 4.0.0
2) change "KMC" to "DCS" in text files.  The file paths, package names, etc. should still use "kmc".