### PR TITLE
consolidating bouncycastle versions

### DIFF
--- a/kmc-crypto-library/pom.xml
+++ b/kmc-crypto-library/pom.xml
@@ -216,7 +216,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bc-fips</artifactId>
-      <version>2.0.0</version>
+      <version>${bcfips.version}</version>
     </dependency>
 
     <dependency>

--- a/kmc-crypto-service/pom.xml
+++ b/kmc-crypto-service/pom.xml
@@ -266,7 +266,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bctls-fips</artifactId>
-      <version>2.1.20</version>
+      <version>${bctls-fips.version}</version>
     </dependency>
   </dependencies>
 

--- a/kmc-sa-mgmt/pom.xml
+++ b/kmc-sa-mgmt/pom.xml
@@ -350,12 +350,12 @@
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bctls-fips</artifactId>
-                <version>2.0.19</version>
+                <version>${bctls-fips.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bc-fips</artifactId>
-                <version>2.0.0</version>
+                <version>${bcfips.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/kmc-sdls-service/pom.xml
+++ b/kmc-sdls-service/pom.xml
@@ -111,12 +111,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bc-fips</artifactId>
-            <version>2.0.0</version>
+            <version>${bcfips.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bctls-fips</artifactId>
-            <version>2.0.19</version>
+            <version>${bctls-fips.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/kmc-sdls-service/pom.xml
+++ b/kmc-sdls-service/pom.xml
@@ -16,6 +16,8 @@
     <properties>
         <java.version>17</java.version>
         <log4j.version>2.24.2</log4j.version>
+        <bcfips.version>2.1.1</bcfips.version>
+        <bctls-fips.version>2.1.20</bctls-fips.version>
         <final.name>sdls-service</final.name>
         <app.profiles>mTLS</app.profiles>
         <spring.profiles.active>${app.profiles}</spring.profiles.active>

--- a/kmip-client/pom.xml
+++ b/kmip-client/pom.xml
@@ -139,7 +139,7 @@
    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bc-fips</artifactId>
-      <version>2.0.0</version>
+      <version>${bcfips.version}</version>
    </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <log4j.version>2.25.1</log4j.version>
     <gson.version>2.13.1</gson.version>
     <bcfips.version>2.1.1</bcfips.version>
+    <bctls-fips.version>2.1.20</bctls-fips.version>
     <junit.version>4.13.2</junit.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
While updating bc-fips and bctls-fips versions for kmc-sa-mgmt, I noticed that the various DCS modules were using inconsistent versions for bcfips and bctls-fips.

bc-fips v2.1.1
bctls-fips v2.1.20

- Created new property in base POM for bctls-fips version
- Applied versions consistently to all submodule POMs