### PR TITLE
Fix python client AOS hex print function

### DIFF
--- a/ammos-cryptolib/kmc_sdls/kmc_sdls_python/KmcSdlsClient/src/gov/nasa/jpl/ammos/kmc/sdlsclient/KmcSdlsClient.py
+++ b/ammos-cryptolib/kmc_sdls/kmc_sdls_python/KmcSdlsClient/src/gov/nasa/jpl/ammos/kmc/sdlsclient/KmcSdlsClient.py
@@ -649,7 +649,8 @@ class KmcSdlsClient:
                                    , aos_result.aos_header.sf
                                    , aos_result.aos_header.spare
                                    , aos_result.aos_header.vfcc
-                                   , aos_result.aos_header.fhecf)
+                                   , aos_result.aos_header.fhecf
+                                   , aos_result.aos_sec_header.iz)
             , FrameSecurityHeader(
                 0,  # segment header
                 aos_result.aos_sec_header.spi,
@@ -853,7 +854,7 @@ class AOS_FramePrimaryHeader(NamedTuple):
         vcflag_b = Bits(uint=self.vcflag, length=1)
         l += 1
         spare_b = Bits(uint=self.spare, length=2)
-        l += 1
+        l += 2
         vcfcc_b = Bits(uint=self.vcfcc, length=4)
         l += 4
         if has_fhec:
@@ -869,7 +870,7 @@ class AOS_FramePrimaryHeader(NamedTuple):
         header.overwrite(scid_b, pos)
         pos += 8
         header.overwrite(vcid_b, pos)
-        pos += 8
+        pos += 6
         header.overwrite(vcfc_b, pos)
         pos += 24
         header.overwrite(replay_b, pos)

--- a/ammos-cryptolib/kmc_sdls/kmc_sdls_python/_cffi_src/cffi_definitions.i
+++ b/ammos-cryptolib/kmc_sdls/kmc_sdls_python/_cffi_src/cffi_definitions.i
@@ -322,15 +322,15 @@ typedef struct
 
 typedef struct
 {
-    uint8_t tfvn : 2;
-    uint8_t scid : 8;
-    uint8_t vcid : 6;
-    long vcfc : 24;
-    uint8_t rf : 1;
-    uint8_t sf : 1;
-    uint8_t spare : 2;
-    uint8_t vfcc : 4;
-    uint16_t fhecf : 16;
+    uint8_t tfvn;
+    uint8_t scid;
+    uint8_t vcid;
+    uint32_t vcfc;
+    uint8_t rf;
+    uint8_t sf;
+    uint8_t spare;
+    uint8_t vfcc;
+    uint16_t fhecf;
 } AOS_FramePrimaryHeader_t;
 
 typedef struct


### PR DESCRIPTION
Worked with Donovan to get AOS working by taking the bitfields out of the AOS frame primary header struct in CryptoLib. This exposed an issue with the bit math for printing AOS frame contents, which is fixed by this PR.