### PR TITLE
migrate crypto-service from javax.servlet-api to jakarta.servlet-api

### DIFF
--- a/kmc-crypto-service/pom.xml
+++ b/kmc-crypto-service/pom.xml
@@ -248,9 +248,9 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/model/Status.java
+++ b/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/model/Status.java
@@ -1,6 +1,6 @@
 package gov.nasa.jpl.ammos.kmc.crypto.model;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Status response of the key service.

--- a/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/CryptoKeyService.java
+++ b/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/CryptoKeyService.java
@@ -2,13 +2,13 @@ package gov.nasa.jpl.ammos.kmc.crypto.service;
 
 import java.io.IOException;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/CryptoServiceHealth.java
+++ b/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/CryptoServiceHealth.java
@@ -2,11 +2,11 @@ package gov.nasa.jpl.ammos.kmc.crypto.service;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet("/health")
 public class CryptoServiceHealth extends HttpServlet {

--- a/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/CryptoServiceStatus.java
+++ b/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/CryptoServiceStatus.java
@@ -2,12 +2,12 @@ package gov.nasa.jpl.ammos.kmc.crypto.service;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/CryptoServiceUtilities.java
+++ b/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/CryptoServiceUtilities.java
@@ -4,7 +4,7 @@ import java.security.Provider;
 import java.security.Security;
 import java.util.Enumeration;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 

--- a/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/DecryptService.java
+++ b/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/DecryptService.java
@@ -7,13 +7,13 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Base64;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +65,7 @@ public class DecryptService extends HttpServlet {
      *
      * Post URI: /decrypt?metadata=value
      *
-     * @see javax.servlet.http.HttpServlet#doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     * @see jakarta.servlet.http.HttpServlet#doPost(jakarta.servlet.http.HttpServletRequest, jakarta.servlet.http.HttpServletResponse)
      *
      */
     @Override

--- a/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/EncryptService.java
+++ b/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/EncryptService.java
@@ -6,13 +6,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +64,7 @@ public class EncryptService extends HttpServlet {
     /*
      * Post URI: /encrypt?keyRef=string&transformation=string&iv=base64&encryptOffset=int&macLength=int
      *
-     * @see javax.servlet.http.HttpServlet#doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     * @see jakarta.servlet.http.HttpServlet#doPost(jakarta.servlet.http.HttpServletRequest, jakarta.servlet.http.HttpServletResponse)
      */
     @Override
     protected final void doPost(final HttpServletRequest request, final HttpServletResponse response)

--- a/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/IcvCreateService.java
+++ b/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/IcvCreateService.java
@@ -5,13 +5,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/IcvVerifyService.java
+++ b/kmc-crypto-service/src/main/java/gov/nasa/jpl/ammos/kmc/crypto/service/IcvVerifyService.java
@@ -5,13 +5,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
The `status` and `health` (and other) controllers for the crypto-service were not being picked up by Spring because newer versions expect `jakarta.servlet-api` annotations instead of `javax.servlet-api`.

This PR changes the dependency and imports from `javax.servlet-api:4.0.1` to `jakarta.servlet-api:6.1.0`